### PR TITLE
Show Details Label/Tire or Show on selection

### DIFF
--- a/eLab/src/app/note/KDetails/k-details.component.ts
+++ b/eLab/src/app/note/KDetails/k-details.component.ts
@@ -10,6 +10,7 @@ import { Location } from '@angular/common';
 export class KDetailsPage implements OnInit{
     path : 'view' | 'new' = 'new';
     type : 'shoe' | 'tire' = 'tire';
+    whichDetails : 'kDetails'; 
 
     KtypeModel : number = 0;
     Ktype = [];

--- a/eLab/src/app/note/QDetails/qdetails.component.ts
+++ b/eLab/src/app/note/QDetails/qdetails.component.ts
@@ -11,6 +11,7 @@ import { Location } from '@angular/common';
 
 export class QDetailsPage implements OnInit{
 	path: 'view' | 'new' = 'new';
+    whichDetails : 'qDetails';
 
 	QtypeModel: number = 0;
 	Qtype = [];

--- a/eLab/src/app/note/evidence-table/evidence-table.component.ts
+++ b/eLab/src/app/note/evidence-table/evidence-table.component.ts
@@ -33,7 +33,7 @@ export class EvidenceTable implements OnInit{
                 isShoe : true,
             },
             {
-                selected : true,
+                selected : false,
                 id : 3,
                 name : "Evidence Name 3",
                 isktype : true,
@@ -51,21 +51,10 @@ export class EvidenceTable implements OnInit{
     }
 
     showTypeLabels(content) {
-        var shoeTireLabel = document.getElementById("shoeTireLabel" + content.id)
-        var typeLabel = document.getElementById("typeLabel" + content.id)
-        if(content.isktype === true) {
-            //if it has a class of hidden
-            //remove class on element with id [attr.id]="'typeLabel' + content.id"
-            //otherwise add it
-            //then show the label k label and shoe if shoe and tire if tire
-            //for shoetire label element
-            console.log("Is a k type");
-        } else {
-            //if it has a class of hidden
-            //remove class on element with id [attr.id]="'typeLabel' + content.id"
-            //to show that it is qtype button
-            console.log("isn't k type");
-        }
+        var shoeTireLabel = $("#shoeTireLabel" + content.id)
+        var typeLabel = $("#typeLabel" + content.id);
+        shoeTireLabel.toggleClass('hidden');
+        typeLabel.toggleClass('hidden');
     }    
 
 }

--- a/eLab/src/app/note/evidence-table/evidence-table.component.ts
+++ b/eLab/src/app/note/evidence-table/evidence-table.component.ts
@@ -50,6 +50,22 @@ export class EvidenceTable implements OnInit{
 
     }
 
-    
+    showTypeLabels(content) {
+        var shoeTireLabel = document.getElementById("shoeTireLabel" + content.id)
+        var typeLabel = document.getElementById("typeLabel" + content.id)
+        if(content.isktype === true) {
+            //if it has a class of hidden
+            //remove class on element with id [attr.id]="'typeLabel' + content.id"
+            //otherwise add it
+            //then show the label k label and shoe if shoe and tire if tire
+            //for shoetire label element
+            console.log("Is a k type");
+        } else {
+            //if it has a class of hidden
+            //remove class on element with id [attr.id]="'typeLabel' + content.id"
+            //to show that it is qtype button
+            console.log("isn't k type");
+        }
+    }    
 
 }

--- a/eLab/src/app/note/evidence-table/evidence-table.template.html
+++ b/eLab/src/app/note/evidence-table/evidence-table.template.html
@@ -18,7 +18,7 @@
         <div *ngFor = "let content of evidenceDetails">
             <div class="col-xs-12 col-sm-12 col-md-12 table-heading">
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div class="pd-t-05"><input type="checkbox" value="content.selected" [(ngModel)]="content.selected"></div>
+                    <div class="pd-t-05"><input type="checkbox" value="content.selected" [(ngModel)]="content.selected" (change)="showTypeLabels(content)"></div>
                 </div>
                 <div class="col-xs-12 col-sm-3 col-md-3">
                     <h6>{{content.id}}</h6>
@@ -27,10 +27,11 @@
                     <h6>{{content.name}}</h6>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div *ngIf="content.isShoe" class="pd-t-05"><span class="label label-primary p-05">{{path == "shoe" ? 'Shoe' : 'Tire'}}</span></div>
+                    <div *ngIf="content.isShoe" class="pd-t-05 hidden" [attr.id]="'shoeTireLabel' + content.id"><span class="label label-primary p-05">{{path == "shoe" ? 'Shoe' : 'Tire'}}</span></div>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div *ngIf="content.isktype" class="pd-t-05"><span class="label label-primary p-05">K type</span></div>
+                    <div *ngIf="content.isktype" class="pd-t-05 hidden" [attr.id]="'typeLabel' + content.id"><span class="label label-primary p-05">K type</span></div>
+                    <!-- if content.isktype is true show K Type otherwise show Q type -->
                 </div>
             </div>
         </div>

--- a/eLab/src/app/note/evidence-table/evidence-table.template.html
+++ b/eLab/src/app/note/evidence-table/evidence-table.template.html
@@ -27,10 +27,10 @@
                     <h6>{{content.name}}</h6>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div *ngIf="content.isktype" class="pd-t-05 hidden" [attr.id]="'shoeTireLabel' + content.id"><span class="label label-primary p-05">{{path == "shoe" ? 'Shoe' : 'Tire'}}</span></div>
+                    <div *ngIf="content.isktype" class="pd-t-05 hidden" [attr.id]="'shoeTireLabel' + content.id"><span class="label label-primary p-05">{{path === "shoe" ? 'Shoe' : 'Tire'}}</span></div>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div class="pd-t-05 hidden" [attr.id]="'typeLabel' + content.id"><span class="label label-primary p-05">{{whichDetails == 'kDetails' ? 'kDetails' : 'qDetails'}}</span></div>
+                    <div class="pd-t-05 hidden" [attr.id]="'typeLabel' + content.id"><span class="label label-primary p-05">{{whichDetails === 'kDetails' ? 'kDetails' : 'qDetails'}}</span></div>
 
                 </div>
             </div>

--- a/eLab/src/app/note/evidence-table/evidence-table.template.html
+++ b/eLab/src/app/note/evidence-table/evidence-table.template.html
@@ -18,7 +18,7 @@
         <div *ngFor = "let content of evidenceDetails">
             <div class="col-xs-12 col-sm-12 col-md-12 table-heading">
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div class="pd-t-05"><input type="checkbox" value="content.selected" [(ngModel)]="content.selected" (change)="showTypeLabels(content)"></div>
+                    <div class="pd-t-05"><input type="checkbox" value="content.selected" [(ngModel)]="content.selected" (change)="showTypeLabels(content)" [attr.id]="'checkbox' + content.id"></div>
                 </div>
                 <div class="col-xs-12 col-sm-3 col-md-3">
                     <h6>{{content.id}}</h6>
@@ -27,11 +27,11 @@
                     <h6>{{content.name}}</h6>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div *ngIf="content.isShoe" class="pd-t-05 hidden" [attr.id]="'shoeTireLabel' + content.id"><span class="label label-primary p-05">{{path == "shoe" ? 'Shoe' : 'Tire'}}</span></div>
+                    <div *ngIf="content.isktype" class="pd-t-05 hidden" [attr.id]="'shoeTireLabel' + content.id"><span class="label label-primary p-05">{{path == "shoe" ? 'Shoe' : 'Tire'}}</span></div>
                 </div>
                 <div class="col-xs-12 col-sm-2 col-md-2">
-                    <div *ngIf="content.isktype" class="pd-t-05 hidden" [attr.id]="'typeLabel' + content.id"><span class="label label-primary p-05">K type</span></div>
-                    <!-- if content.isktype is true show K Type otherwise show Q type -->
+                    <div class="pd-t-05 hidden" [attr.id]="'typeLabel' + content.id"><span class="label label-primary p-05">{{whichDetails == 'kDetails' ? 'kDetails' : 'qDetails'}}</span></div>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Alright, this has me completely stumped.
- eLab/src/app/note/evidence-table/evidence-table.template.html: In the evidence table I added logic to only show the tire/shoe if `ktype` is true since we're not showing tire/shoe on the q details page. 
- k-details.component.ts + q-details.component.ts: In both of these files I defined 'whichdetails' to call on the view and then display kdetails if which details is kdetails (similar to how we defined `path` on other files), however, I can't seem to figure out why it isn't working. At the moment none of the conditional logic seems to be working, but you can toggle through showing them.

![kdetailsscreenshot](https://cloud.githubusercontent.com/assets/13513340/25465326/8a0ed338-2acf-11e7-8940-d02463667ec8.png)
